### PR TITLE
Export `Event` type

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -75,6 +75,9 @@ import type {
   Untouch
 } from './actions.types'
 
+import { type Event as _Event } from './types'
+export type Event = _Event
+
 type StructureMap = Object
 
 export type FormProps = _FormProps


### PR DESCRIPTION
Currently, `import { type Event } from 'redux-form'` makes Flow complain about not found `Event`. This fixes it.